### PR TITLE
Simple patch to pass context or eval in `cb` context.

### DIFF
--- a/lib/cb.js
+++ b/lib/cb.js
@@ -10,7 +10,7 @@ module.exports = function(callback, context) {
 		var args = Array.prototype.slice.call(arguments);
 		process.nextTick(function() {
 			if (!errback) return callback.apply(context, args);
-			args[0] ? errback(args[0]) : callback.apply(context, args.slice(1));
+			args[0] ? errback.call(context, args[0]) : callback.apply(context, args.slice(1));
 		});
 
 	}, count = 0, once = false, timedout = false, errback, tid;


### PR DESCRIPTION
This patch saving original context or allow to define custom context of function.
