### PR TITLE
Generate a uid for each callback

### DIFF
--- a/lib/cb.js
+++ b/lib/cb.js
@@ -1,3 +1,5 @@
+var uid = require('node-uuid');
+
 module.exports = function(callback) {
 
 	var cb = function() {
@@ -12,7 +14,9 @@ module.exports = function(callback) {
 		});
 
 	}, count = 0, once = false, timedout = false, errback, tid;
-
+        
+        cb.uid = uid.v4();
+        
 	cb.timeout = function(ms) {
 		tid && clearTimeout(tid);
 		tid = setTimeout(function() {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
 		"url" : "git://github.com/jmar777/cb.git"
 	},
 	"main": "lib/cb.js",
+        "dependencies": {
+            "node-uuid": "1.4.x"            
+        },
 	"devDependencies": {
 		"mocha": ">=0.3.6"
 	},

--- a/test/tests.js
+++ b/test/tests.js
@@ -123,3 +123,13 @@ describe('cb(callback).once()', function() {
 	});
 
 });
+
+describe('cb(callback).uid', function() {
+
+	it('should have a unique id', function() {
+            var _cb = cb(function() {});
+
+            assert.strictEqual(typeof _cb.uid, 'string');
+	});
+
+});


### PR DESCRIPTION
This will generate a unique id for each callback, useful for when transmitting over network, and also will be vital for the next pull request which will deal with freeing callbacks from emitters.

It does introduce a dependency on node-uuid, the next PR will do it without node-uuid if you want to avoid the dependency and support for network.
