### PR TITLE
Free's the callback from emitters

### DIFF
--- a/lib/cb.js
+++ b/lib/cb.js
@@ -1,3 +1,5 @@
+var uid = 0;
+
 module.exports = function(callback) {
 
 	var cb = function() {
@@ -11,12 +13,52 @@ module.exports = function(callback) {
 			args[0] ? errback(args[0]) : callback.apply(this, args.slice(1));
 		});
 
-	}, count = 0, once = false, timedout = false, errback, tid;
+	}, count = 0, once = false, timedout = false, emitters = [], errback, tid;
+        
+        cb.uid = ++uid;
+        
+        cb.emitter = function(eventEmitter) {
+            var EventEmitter = require('events').EventEmitter;
+
+            if (eventEmitter instanceof EventEmitter) {
+                emitters.push(eventEmitter);
+            }
+            
+            return cb;
+        }
+        
+        cb.free = function() {                        
+            if (emitters.length) {
+                emitters.forEach(function(ee) {
+                    var events = Object.keys(ee._events);
+                    
+                    events.forEach(function(e) {
+                        var listeners = ee.listeners(e);
+                        
+                        for (var i=0; i < listeners.length; i++) {
+                            if (listeners[i].uid && listeners[i].uid == cb.uid) {
+                                delete listeners[i];
+                                break;
+                            }
+                        }
+                                                                        
+                        ee._events[e] = listeners.filter(function(l) {
+                            return l;
+                        });
+                    })  
+                })
+            }
+            
+            emitters = [];
+            
+            return cb;                        
+        }
 
 	cb.timeout = function(ms) {
 		tid && clearTimeout(tid);
 		tid = setTimeout(function() {
-			cb(new TimeoutError(ms));
+                        cb.free();
+			cb(new TimeoutError(ms));                        
 			timedout = true;
 		}, ms);
 		return cb;

--- a/test/tests.js
+++ b/test/tests.js
@@ -123,3 +123,33 @@ describe('cb(callback).once()', function() {
 	});
 
 });
+
+describe('cb(callback).emitter()', function() {
+	it('should remove callback from eventemitter(s)', function() {
+		var emitter = new (require('events').EventEmitter)(),
+                    _cb     = cb(function() {}).emitter(emitter);
+                
+                emitter.on('testing', _cb);
+                
+                assert.strictEqual(1, emitter.listeners('testing').length);
+                
+                _cb.free();
+                
+                assert.strictEqual(0, emitter.listeners('testing').length);
+	});
+        
+        it('should remove callback from eventemitter(s) on timeout', function(done) {
+                var emitter = new (require('events').EventEmitter)(),
+                    _cb     = cb(function(err, res) {
+			assert(err);
+                        assert.strictEqual(0, emitter.listeners('testing').length);
+			done();
+		}).emitter(emitter);
+                
+                emitter.on('testing', _cb);
+                
+                assert.strictEqual(1, emitter.listeners('testing').length);
+                
+		invokeAsync(_cb.timeout(50));
+	});
+});


### PR DESCRIPTION
Free the callback automatically on timeout, or via the `cb.free()` method from emitters. 

emitters are added using `cb.emitter(ee);`
