### PR TITLE
Feature timeout handler

### DIFF
--- a/lib/cb.js
+++ b/lib/cb.js
@@ -13,22 +13,17 @@ module.exports = function(callback) {
 
 	}, count = 0, once = false, timedout = false, timeoutError = TimeoutError, errback, tid;
 
-	cb.timeout = function(ms) {
+	cb.timeout = function(ms, handler) {
 		tid && clearTimeout(tid);
 		tid = setTimeout(function() {
 			cb(new timeoutError(ms));
 			timedout = true;
 		}, ms);
+                if (handler && typeof handler == 'function') {
+                    timeoutError = handler;
+                }
 		return cb;
 	};
-        
-        cb.timeoutError = function(err) {
-            if (err && typeof err == 'function') {
-               timeoutError = err;
-            }
-            
-            return cb;
-        }
 
 	cb.error = function(func) { errback = func; return cb; };
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -82,7 +82,7 @@ describe('cb(callback).timeout(ms)', function() {
 		invokeAsync(cb(function(err, res) {        
 			assert(err instanceof CustomError);
 			done();
-		}).timeoutError(CustomError).timeout(50));
+		}).timeout(50, CustomError));
 	});
 
 });


### PR DESCRIPTION
Adds the ability to use a custom timeout handler, currently we expose TimeoutError but no way to inherit from it and apply it to callbacks as a handler.
