### PR TITLE
Allows for rolling timeouts (interval timeouts)

### DIFF
--- a/lib/cb.js
+++ b/lib/cb.js
@@ -7,11 +7,18 @@ module.exports = function(callback) {
 
 		var args = Array.prototype.slice.call(arguments);
 		process.nextTick(function() {
-			if (!errback) return callback.apply(this, args);
-			args[0] ? errback(args[0]) : callback.apply(this, args.slice(1));
+			if (!errback) {
+                            callback.apply(this, args);
+                        } else {
+			    args[0] ? errback(args[0]) : callback.apply(this, args.slice(1));
+                        }
+                        
+                        if (interval) {                          
+                            cb.timeout(interval);
+                        }
 		});
 
-	}, count = 0, once = false, timedout = false, errback, tid;
+	}, count = 0, once = false, timedout = false, interval = false, errback, tid;
 
 	cb.timeout = function(ms) {
 		tid && clearTimeout(tid);
@@ -21,6 +28,16 @@ module.exports = function(callback) {
 		}, ms);
 		return cb;
 	};
+        
+        cb.interval = function(iv) {
+            interval = iv;
+            
+            if (iv) {
+                cb.timeout(iv);
+            }
+            
+            return cb;
+        };
 
 	cb.error = function(func) { errback = func; return cb; };
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -123,3 +123,61 @@ describe('cb(callback).once()', function() {
 	});
 
 });
+
+describe('cb(callback).interval()', function() {
+    it('should allow for a timeout to be extended and called', function(done) {
+		var count = 0,                   
+                    start,
+                    iid,
+                    _cb   = cb(function(err, res) {
+                        if (! count) {
+                            start = new Date().getTime();
+                        }
+                        
+                        if (count > 5) {
+                            clearInterval(iid); 
+                        }
+                        
+                        if (err) {
+                            assert((new Date().getTime() - start) > 1000);
+                            done();
+                        }
+                        
+                        ++count;
+		    }).interval(500);
+                    
+                this.timeout(5000);   
+                
+                this.slow(5000);
+                    
+                iid = setInterval(_cb, 200);                  		
+    });
+    
+    it('should allow for interval to be cancelled', function(done) {
+		var count = 0,                   
+                    iid,
+                    _cb   = cb(function(err, res) {                       
+                        if (count == 6) {
+                            clearInterval(iid);
+                            _cb.interval(false);
+                        }
+                        
+                        if (err) {                            
+                            throw new Error('Should not timeout if interval is cancelled');
+                        }
+                        
+                        ++count;
+		    }).interval(500);
+                    
+                this.timeout(10000);   
+                
+                this.slow(10000);
+                    
+                iid = setInterval(_cb, 200); 
+                
+                setTimeout(function() {   
+                    assert(count == 7);
+                    done();                    
+                }, 4000);
+    });
+})


### PR DESCRIPTION
This will allow for users to have a rolling timeouts for callbacks that
should be called regularly.

How

`cb.interval(1000)` sets a timeout and has it reset on each iteration
`cb.interval(false)` clears interval, does not effect any current timers
